### PR TITLE
Delay log file creation

### DIFF
--- a/logconfig.py
+++ b/logconfig.py
@@ -43,7 +43,8 @@ default_config = {
             "filename": "debug.log",
             "maxBytes": 1048576,
             "backupCount": 20,
-            "encoding": "utf8"
+            "encoding": "utf8",
+            "delay" : True
         },
 
         "graylog_gelf": {


### PR DESCRIPTION
The log file was created when the handler was instantiated even if no logger used it, this could be a problem when the current directory is read-only.

When delay is set to True, the file is created on the first call to emit.